### PR TITLE
Add support for pre-release versions

### DIFF
--- a/tests/VersionTest.php
+++ b/tests/VersionTest.php
@@ -293,8 +293,13 @@ class VersionText extends TestCase
      * @test
      * @dataProvider provide_control_versions()
      */
-    public function all_examples_from_the_specification_should_pass(string $version, int $major, int $minor, int $patch, string $prerelease)
-    {
+    public function all_examples_from_the_specification_should_pass(
+        string $version,
+        int $major,
+        int $minor,
+        int $patch,
+        string $prerelease
+    ) {
         $version = new Version($version);
 
         $this->assertSame($major, $version->getMajorVersion());

--- a/tests/VersionTest.php
+++ b/tests/VersionTest.php
@@ -44,6 +44,23 @@ class VersionText extends TestCase
     /**
      * @test
      * @group Getters
+     * @covers \SteveGrunwell\SemVer\Version::getVersion
+     * @ticket https://github.com/stevegrunwell/semver-parser/issues/1
+     */
+    public function getVersion_should_include_the_prerelease_when_available()
+    {
+        $version = new Version;
+        $version->setMajorVersion(1);
+        $version->setMinorVersion(2);
+        $version->setPatchVersion(3);
+        $version->setPreReleaseVersion('alpha');
+
+        $this->assertSame('1.2.3-alpha', $version->getVersion());
+    }
+
+    /**
+     * @test
+     * @group Getters
      * @covers \SteveGrunwell\SemVer\Version::getMajorVersion
      */
     public function getMajorVersion_should_return_the_major_version()
@@ -82,9 +99,35 @@ class VersionText extends TestCase
      * @dataProvider provide_version_getters_and_setters
      * @group Getters
      */
-    public function getters_should_default_to_zero(string $getter)
+    public function digit_getters_should_default_to_zero(string $getter)
     {
         $this->assertSame(0, (new Version)->{$getter}());
+    }
+
+    /**
+     * @test
+     * @group Getters
+     * @covers \SteveGrunwell\SemVer\Version::getPreReleaseVersion
+     * @ticket https://github.com/stevegrunwell/semver-parser/issues/1
+     */
+    public function getPreReleaseVersion_should_return_the_prerelease_version()
+    {
+        $version = new Version('1.2.3-alpha');
+
+        $this->assertSame('alpha', $version->getPreReleaseVersion());
+    }
+
+    /**
+     * @test
+     * @group Getters
+     * @covers \SteveGrunwell\SemVer\Version::getPreReleaseVersion
+     * @ticket https://github.com/stevegrunwell/semver-parser/issues/1
+     */
+    public function getPreReleaseVersion_should_default_to_an_empty_string()
+    {
+        $version = new Version('1.2.3');
+
+        $this->assertSame('', $version->getPreReleaseVersion());
     }
 
     /**
@@ -128,16 +171,45 @@ class VersionText extends TestCase
 
     /**
      * @test
+     * @group Setters
+     * @covers \SteveGrunwell\SemVer\Version::setPreReleaseVersion()
+     * @ticket https://github.com/stevegrunwell/semver-parser/issues/1
+     */
+    public function setPreReleaseVersion_sets_the_prerelease_version()
+    {
+        $version = new Version('1.2.3-alpha');
+        $version->setPreReleaseVersion('beta');
+
+        $this->assertSame('1.2.3-beta', $version->getVersion());
+    }
+
+    /**
+     * @test
      * @testdox Setters should not accept non-negative values
      * @dataProvider provide_version_getters_and_setters()
      * @group Setters
      */
-    public function setters_should_not_accept_non_negative_values(string $getter, string $setter)
+    public function digit_setters_should_not_accept_non_negative_values(string $getter, string $setter)
     {
         $this->expectException(InvalidVersionException::class);
 
-        $version = new Version;
-        $version->{$setter}(-2);
+        (new Version)->{$setter}(-2);
+    }
+
+    /**
+     * @test
+     * @testdox Pre-release versions may only contain alphanumeric characters, hyphens, and dots
+     * @dataProvider provide_invalid_identifiers()
+     * @group Setters
+     * @covers \SteveGrunwell\SemVer\Version::setPreReleaseVersion()
+     * @ticket https://github.com/stevegrunwell/semver-parser/issues/1
+     * @link https://semver.org/spec/v2.0.0.html#spec-item-9
+     */
+    public function prerelease_versions_should_be_validated(string $identifier)
+    {
+        $this->expectException(InvalidVersionException::class);
+
+        (new Version)->setPreReleaseVersion($identifier);
     }
 
     /**
@@ -145,7 +217,7 @@ class VersionText extends TestCase
      * @group Setters
      * @dataProvider provide_version_getters_and_setters()
      */
-    public function values_can_be_incremented(string $getter, string $setter)
+    public function digit_values_can_be_incremented(string $getter, string $setter)
     {
         $version = new Version;
         $method  = 'increment' . substr($setter, 3);
@@ -191,7 +263,7 @@ class VersionText extends TestCase
      * @group Setters
      * @dataProvider provide_version_getters_and_setters()
      */
-    public function values_can_be_decremented(string $getter, string $setter)
+    public function digit_values_can_be_decremented(string $getter, string $setter)
     {
         $version = new Version;
         $method  = 'decrement' . substr($setter, 3);
@@ -206,7 +278,7 @@ class VersionText extends TestCase
      * @group Setters
      * @dataProvider provide_version_getters_and_setters()
      */
-    public function values_cannot_be_decremented_below_zero(string $getter, string $setter)
+    public function digit_values_cannot_be_decremented_below_zero(string $getter, string $setter)
     {
         $version = new Version;
         $method  = 'decrement' . substr($setter, 3);
@@ -218,6 +290,40 @@ class VersionText extends TestCase
     }
 
     /**
+     * @test
+     * @dataProvider provide_control_versions()
+     */
+    public function all_examples_from_the_specification_should_pass(string $version, int $major, int $minor, int $patch, string $prerelease)
+    {
+        $version = new Version($version);
+
+        $this->assertSame($major, $version->getMajorVersion());
+        $this->assertSame($minor, $version->getMinorVersion());
+        $this->assertSame($patch, $version->getPatchVersion());
+        $this->assertSame($prerelease, $version->getPreReleaseVersion());
+    }
+
+    /**
+     * As a control, include examples given in the specification.
+     */
+    public function provide_control_versions(): array
+    {
+        return [
+            // https://semver.org/spec/v2.0.0.html#spec-item-9
+            ['1.0.0-alpha', 1, 0, 0, 'alpha' ],
+            ['1.0.0-alpha.1', 1, 0, 0, 'alpha.1'],
+            ['1.0.0-0.3.7', 1, 0, 0, '0.3.7'],
+            ['1.0.0-x.7.z.92', 1, 0, 0, 'x.7.z.92'],
+
+            // If digits are missing, treat them as zeros.
+            ['1.0', 1, 0, 0, ''],
+            ['1', 1, 0, 0, ''],
+            ['1-alpha', 1, 0, 0, 'alpha'],
+            ['1-alpha.1', 1, 0, 0, 'alpha.1']
+        ];
+    }
+
+    /**
      * Return all of the available version setter methods.
      */
     public function provide_version_getters_and_setters(): array
@@ -226,6 +332,17 @@ class VersionText extends TestCase
             'Major' => ['getMajorVersion', 'setMajorVersion'],
             'Minor' => ['getMinorVersion', 'setMinorVersion'],
             'Patch' => ['getPatchVersion', 'setPatchVersion'],
+        ];
+    }
+
+    /**
+     * Provide invalid pre-release version identifiers.
+     */
+    public function provide_invalid_identifiers(): array
+    {
+        return [
+            'Whitespace'  => ['alpha v1'],
+            'Underscores' => ['alpha_v1'],
         ];
     }
 }


### PR DESCRIPTION
If a hyphen ('-') is detected in the version string, this will be split out into the pre-release value, which consists of one or more dot-separated identifiers, each consisting of ASCII alphanumerics and/or hyphens.

Reference: https://semver.org/spec/v2.0.0.html#spec-item-9

Fixes #1.